### PR TITLE
Update .md files for documentation purposes

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -98,11 +98,13 @@ OpenAPI 3.0 with grouped endpoints:
 
 ## Environment Variables (Production)
 
-Essential variables for production deployment:
+Essential variables for production deployment (all required):
 
 - `DATABASE_URL`, `DATABASE_USERNAME`, `DATABASE_PASSWORD`
 - `ADMIN_USERNAME`, `ADMIN_PASSWORD`
 - `SERVER_PORT` (optional, defaults to 8080)
+
+**Security Note**: As of commit 7ff88d1, all authentication credentials must be explicitly provided via environment variables for production deployment - no default values are used to enhance security.
 
 ## Documentation Maintenance
 

--- a/PROFILE_SETUP.md
+++ b/PROFILE_SETUP.md
@@ -37,8 +37,8 @@ This application supports two profiles: `dev` and `prod`.
 
 **Credentials via environment variables:**
 
-- Username: `${ADMIN_USERNAME}` (default: admin)
-- Password: `${ADMIN_PASSWORD}` (default: changeme)
+- Username: `${ADMIN_USERNAME}` (required)
+- Password: `${ADMIN_PASSWORD}` (required)
 
 **Features:**
 
@@ -67,6 +67,9 @@ SERVER_PORT=8080
 
 ```bash
 export SPRING_PROFILES_ACTIVE=prod
+export DATABASE_URL=jdbc:postgresql://localhost:5432/stammdatenverwaltung
+export DATABASE_USERNAME=db_user
+export DATABASE_PASSWORD=db_password
 export ADMIN_USERNAME=prod-admin
 export ADMIN_PASSWORD=secure-password
 ./mvnw spring-boot:run
@@ -132,6 +135,6 @@ docker run -p 8080:8080 \
 | `DATABASE_URL`           | Prod only | -          | Database connection URL |
 | `DATABASE_USERNAME`      | Prod only | -          | Database username       |
 | `DATABASE_PASSWORD`      | Prod only | -          | Database password       |
-| `ADMIN_USERNAME`         | Prod only | `admin`    | Admin username          |
-| `ADMIN_PASSWORD`         | Prod only | `changeme` | Admin password          |
+| `ADMIN_USERNAME`         | Prod only | -          | Admin username          |
+| `ADMIN_PASSWORD`         | Prod only | -          | Admin password          |
 | `SERVER_PORT`            | No        | `8080`     | Server port             |

--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ cd team-11-backend-stammdatenverwaltung
 export SPRING_PROFILES_ACTIVE=prod
 export ADMIN_USERNAME=admin
 export ADMIN_PASSWORD=secure-password
+export DATABASE_URL=jdbc:postgresql://localhost:5432/stammdatenverwaltung
+export DATABASE_USERNAME=db_user
+export DATABASE_PASSWORD=db_password
 ./mvnw spring-boot:run
 ```
 
@@ -271,6 +274,6 @@ The application supports two distinct profiles:
 | `DATABASE_URL`           | prod    | Yes      | -          | PostgreSQL connection URL |
 | `DATABASE_USERNAME`      | prod    | Yes      | -          | Database username         |
 | `DATABASE_PASSWORD`      | prod    | Yes      | -          | Database password         |
-| `ADMIN_USERNAME`         | prod    | No       | `admin`    | Admin username            |
-| `ADMIN_PASSWORD`         | prod    | No       | `changeme` | Admin password            |
+| `ADMIN_USERNAME`         | prod    | Yes      | -          | Admin username            |
+| `ADMIN_PASSWORD`         | prod    | Yes      | -          | Admin password            |
 | `SERVER_PORT`            | Both    | No       | `8080`     | Server port               |


### PR DESCRIPTION
This pull request updates documentation to improve security and clarity for production environment setup. The main change is that all authentication credentials (`ADMIN_USERNAME`, `ADMIN_PASSWORD`, and database credentials) are now required to be explicitly set via environment variables in production, with no default values provided. This prevents accidental use of insecure defaults and ensures proper configuration. The documentation is updated across multiple files to reflect these changes and provide clearer setup instructions.

**Security and environment variable requirements:**

* Updated `.github/copilot-instructions.md`, `README.md`, and `PROFILE_SETUP.md` to require explicit values for `ADMIN_USERNAME`, `ADMIN_PASSWORD`, `DATABASE_URL`, `DATABASE_USERNAME`, and `DATABASE_PASSWORD` in production; removed all default values for credentials to enhance security. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L101-R108) [[2]](diffhunk://#diff-f2f45647c45a97b9572eb3467082b97bb2170666c2b5af005f04a50e2411d880L40-R41) [[3]](diffhunk://#diff-f2f45647c45a97b9572eb3467082b97bb2170666c2b5af005f04a50e2411d880L135-R139) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L274-R278)

**Setup instructions and examples:**

* Added explicit example environment variable exports for database credentials in `README.md` and `PROFILE_SETUP.md` to clarify production setup steps. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R80-R82) [[2]](diffhunk://#diff-f2f45647c45a97b9572eb3467082b97bb2170666c2b5af005f04a50e2411d880R70-R72)

**Documentation consistency:**

* Updated environment variable tables and credential descriptions in all relevant documentation files to consistently indicate that credentials are required and do not have defaults in production. [[1]](diffhunk://#diff-f2f45647c45a97b9572eb3467082b97bb2170666c2b5af005f04a50e2411d880L135-R139) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L274-R278)