### PR TITLE
Small fixes

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -55,6 +55,10 @@ The project includes the following key dependencies and Maven plugins for develo
 - **spring-boot-starter-test**: Comprehensive testing with JUnit 5, Mockito, AssertJ
 - **spring-security-test**: Security-specific testing utilities
 
+### Code Quality & Formatting
+- **Spotless Maven Plugin (v2.43.0)**: Automatic code formatting using Google Java Format
+- **Maven Checkstyle Plugin (v3.5.0)**: Logic and complexity analysis (checkstyle-logic-only.xml)
+
 ### Maven Plugins
 - **spring-boot-maven-plugin**: Application packaging, Docker image building, dev server
 - **maven-compiler-plugin (v3.14.0)**: Java 21 compilation with Lombok annotation processing
@@ -80,17 +84,38 @@ Follow the established package organization under `com.ase.stammdatenverwaltung`
 - `services/` - Business logic (placeholder, add services here)
 - `components/` - Spring components (placeholder, add utilities here)
 
-## Code Style Requirements
+## Code Quality & Style Requirements
 
-Strict Checkstyle enforcement with specific rules:
+The project uses a **dual approach** for code quality:
 
-- **Indentation**: 2 spaces (no tabs), continuation indent 4 spaces
-- **Line length**: 80 characters max
-- **Braces**: Opening brace on same line (`eol`), closing brace alone (`alone`)
-- **Imports**: Ordered groups `java, javax, org, com` with static imports sorted alphabetically
+### ✨ Spotless (Automatic Formatting)
+- **Purpose**: Automatic code formatting using Google Java Format
+- **Handles**: Indentation (2 spaces), line length, import organization, braces, spacing
+- **Behavior**: Automatically fixes formatting issues
+- **Style**: Google Java Style Guide with removed unused imports and formatted annotations
+
+### 🔍 Checkstyle (Logic & Complexity)
+- **Purpose**: Code logic and complexity analysis only (no formatting rules)
+- **Focus**: Best practices, naming conventions, complexity metrics
+- **Rules**: Method length (max 50 lines), cyclomatic complexity (max 10), parameter count (max 7)
 - **Naming**: PascalCase classes, camelCase methods/variables, ALL_CAPS constants
-- **Lombok**: Use `@Data`, `@Builder`, `@NoArgsConstructor`, `@AllArgsConstructor` for entities and DTOs
-- Run locally: `java -jar checkstyle-11.0.0-all.jar -c checkstyle.xml -f plain src\main\java src\test\java`
+- **Behavior**: Reports violations for manual review (warnings only, doesn't fail build)
+
+### Quick Commands
+```bash
+# Format and check (recommended workflow)
+./format-code.cmd                       # Windows
+./format-code.sh                        # Linux/Mac
+
+# Format only
+./format-only.cmd                       # Windows  
+./format-only.sh                        # Linux/Mac
+
+# Individual commands
+./mvnw.cmd spotless:apply              # Auto-format code
+./mvnw.cmd spotless:check              # Check formatting
+./mvnw.cmd checkstyle:check            # Logic/complexity checks
+```
 
 ## Development Workflow
 
@@ -105,8 +130,11 @@ Strict Checkstyle enforcement with specific rules:
 ./mvnw integration-test                 # Integration tests only (Failsafe plugin)
 ./mvnw verify                           # Full verification including integration tests
 
-# Code quality check
-java -jar checkstyle-11.0.0-all.jar -c checkstyle.xml -f plain src\main\java src\test\java
+# Code quality and formatting
+./format-code.cmd                       # Format code + logic checks (Windows)
+./format-code.sh                        # Format code + logic checks (Linux/Mac)
+./mvnw spotless:apply                   # Auto-format code only
+./mvnw checkstyle:check                 # Logic/complexity checks only
 
 # Spring Boot specific commands
 ./mvnw spring-boot:start                # Start app in background for testing

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # 🏢 Stammdatenverwaltung
 
-[![Spring Boot General](https://img.shields.io/badge/Spring%20Boot-3.5.5-6DB33F?style=flat-square&logo=spring-boot)](https://spring.io/projects/spring-boot)
-[![Spring Boot Specifically](https://img.shields.io/badge/Spring%20Boot-3.5.5-6DB33F?style=flat-square&logo=spring-boot)](https://docs.spring.io/spring-boot/index.html)
+[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-3.5.5-6DB33F?style=flat-square&logo=spring-boot)](https://docs.spring.io/spring-boot/index.html)
 [![Java](https://img.shields.io/badge/Java-21-ED8B00?style=flat-square&logo=openjdk)](https://openjdk.org/)
 [![Maven](https://img.shields.io/badge/Maven-3.6+-C71A36?style=flat-square&logo=apache-maven)](https://maven.apache.org/)
-[![License](https://img.shields.io/badge/License-MIT-green?style=flat-square)](LICENSE)
 
 > A modern Spring Boot microservice for **master data management** in the ASE (Agile Software Engineering) project. Built with enterprise-grade security, monitoring, and comprehensive API documentation.
 

--- a/format-code.cmd
+++ b/format-code.cmd
@@ -33,4 +33,3 @@ if %ERRORLEVEL% EQU 0 (
 
 echo.
 echo ================================
-pause

--- a/format-only.cmd
+++ b/format-only.cmd
@@ -9,5 +9,3 @@ if %ERRORLEVEL% EQU 0 (
 ) else (
     echo ❌ Code formatting failed. Please check the error messages above.
 )
-
-pause

--- a/pom.xml
+++ b/pom.xml
@@ -202,6 +202,7 @@
                 </configuration>
                 <executions>
                     <execution>
+                        <?m2e execute onConfiguration,onIncremental?>
                         <id>checkstyle-check</id>
                         <phase>validate</phase>
                         <goals>


### PR DESCRIPTION
This pull request updates the project's documentation and build configuration to clarify and improve code quality enforcement, code formatting, and developer workflow. The main focus is on introducing a dual approach for code quality using both Spotless and Checkstyle, updating related instructions, and making minor improvements to badges and scripts.

**Code Quality & Formatting Improvements**
* Added detailed documentation for the Spotless Maven Plugin and Maven Checkstyle Plugin, describing their roles in automatic formatting and logic/complexity analysis, respectively (`.github/copilot-instructions.md`). [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R58-R61) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L83-R118)
* Expanded the code style section to explain the dual approach: Spotless for formatting (Google Java Style Guide) and Checkstyle for logic and complexity checks, including specific rules and recommended commands for developers (`.github/copilot-instructions.md`).

**Developer Workflow Updates**
* Updated quick commands and workflow instructions to reflect the new formatting and quality check scripts, making it easier for developers to run formatting and logic checks locally (`.github/copilot-instructions.md`).

**Build Configuration**
* Added a directive to the Checkstyle plugin execution in `pom.xml` to improve IDE integration with Maven (specifically for m2e in Eclipse) (`pom.xml`).

**Minor Documentation and Script Improvements**
* Simplified badges in the `README.md` for clarity and removed a duplicate Spring Boot badge (`README.md`).
* Removed unnecessary `pause` statements from the `format-code.cmd` and `format-only.cmd` scripts to streamline their execution (`format-code.cmd`, `format-only.cmd`). [[1]](diffhunk://#diff-a3b845bdcb68b8f8fb13d253f95b7e971aac2fb96fc679f6d1b9e6eac43a4437L36) [[2]](diffhunk://#diff-749375121af1f3a050aa68b7dc5242f1f0ad451c950dae368b4d855a2e684e39L12-L13)