### PR TITLE
fix: remove spotless-check execution to prevent build failures

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,14 +196,6 @@
                         </goals>
                         <phase>process-sources</phase>
                     </execution>
-                    <!-- Check formatting during validate phase -->
-                    <execution>
-                        <id>spotless-check</id>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                        <phase>validate</phase>
-                    </execution>
                 </executions>
             </plugin>
             <!-- Checkstyle Plugin - Logic and Complexity Rules Only -->


### PR DESCRIPTION
- Remove spotless-check execution from validate phase
- Keep spotless-apply in process-sources phase for automatic formatting
- Prevents build failures when code isn't pre-formatted
- Maintains automatic code formatting during builds