### PR TITLE
fix: include checkstyle configuration file in Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -48,7 +48,3 @@ docs/
 
 # Ignore test files for production build
 src/test/
-
-# Ignore checkstyle files (build tools, not runtime)
-checkstyle*.jar
-checkstyle.xml

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,9 @@ RUN chmod +x mvnw && \
 # Download dependencies (this layer will be cached if pom.xml doesn't change)
 RUN ./mvnw dependency:go-offline -B
 
-# Copy the source code
+# Copy the source code and configuration files needed for build
 COPY src ./src
+COPY checkstyle-logic-only.xml ./
 
 # Build the application
 RUN ./mvnw clean package -DskipTests


### PR DESCRIPTION
- Copy checkstyle-logic-only.xml to Docker build context
- Remove checkstyle config files from .dockerignore to allow build access
- Resolves Maven checkstyle plugin unable to find configuration file
- Enables successful Docker image build with code quality checks